### PR TITLE
Enforce stricter lint rules (modernization + accessibility)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,9 @@ export default [
       '@angular-eslint/use-pipe-transform-interface': 'error',
       '@angular-eslint/component-class-suffix': 'error',
       '@angular-eslint/directive-class-suffix': 'error',
+      '@angular-eslint/prefer-inject': 'error',
+      '@angular-eslint/prefer-standalone': 'error',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@angular-eslint/component-selector': [
         'error',
         { prefix: 'rc', style: 'kebab-case', type: 'element' },
@@ -63,6 +66,22 @@ export default [
       '@angular-eslint/template/banana-in-box': 'error',
       '@angular-eslint/template/eqeqeq': 'error',
       '@angular-eslint/template/no-negated-async': 'error',
+      '@angular-eslint/template/prefer-control-flow': 'error',
+      '@angular-eslint/template/alt-text': 'error',
+      '@angular-eslint/template/click-events-have-key-events': 'error',
+      '@angular-eslint/template/elements-content': 'error',
+      '@angular-eslint/template/interactive-supports-focus': 'error',
+      '@angular-eslint/template/mouse-events-have-key-events': 'error',
+      '@angular-eslint/template/no-autofocus': 'error',
+      '@angular-eslint/template/no-distracting-elements': 'error',
+      '@angular-eslint/template/role-has-required-aria': 'error',
+      '@angular-eslint/template/table-scope': 'error',
+      '@angular-eslint/template/valid-aria': 'error',
+      // Disabled: incompatible with Clarity's form idiom. Clarity's
+      // <clr-*-container> wrappers associate a sibling <label> with their
+      // control at runtime, so no static for=/nesting exists for the rule to
+      // assert against — it would flag false positives across Clarity forms.
+      '@angular-eslint/template/label-has-associated-control': 'off',
     },
   },
 ];


### PR DESCRIPTION
## Stricter lint rules

Third andromeda-parity step (after ESLint 10 / async animations / budget). Extends `eslint.config.mjs` with modernization and accessibility rules. **The codebase already satisfies all of them**, so this is a zero-code-change enforcement upgrade — it locks in current quality and catches future regressions. Worked on `chore/lint-rules`; **please review — do not merge yet.**

### Rules added (all pass with no violations)

**TypeScript**
- `@angular-eslint/prefer-inject` — no constructor DI to convert
- `@angular-eslint/prefer-standalone` — all components already standalone
- `@typescript-eslint/no-explicit-any` — no explicit `any` in the codebase

**Templates** (`.html` — the `.svg` templates aren't in the lint globs)
- `prefer-control-flow` — templates already use `@if`/`@for`
- accessibility: `alt-text`, `click-events-have-key-events`, `elements-content`, `interactive-supports-focus`, `mouse-events-have-key-events`, `no-autofocus`, `no-distracting-elements`, `role-has-required-aria`, `table-scope`, `valid-aria`
- `label-has-associated-control` **disabled** — Clarity's wrapper form idiom associates labels at runtime, so the static rule false-positives

### Verification

- `npm run lint` passes; I confirmed the template rules are genuinely active (a deliberately injected `valid-aria` violation is caught, then reverted).
- Build passes; `npm audit` clean.

### Still queued (bigger, own PRs)

- **Zoneless change detection** — the Angular 22 migration pinned eager CD, so going zoneless reverses that and needs per-view verification.
- **Lazy-loaded routes** for the docs / architecture / instruction-set tabs — the real lever for shrinking the initial chunk further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)