### PR TITLE
Fix LOAD opcode on the instruction-set page

### DIFF
--- a/src/app/components/instrset/instrset.component.html
+++ b/src/app/components/instrset/instrset.component.html
@@ -141,7 +141,7 @@
         <td class="classbit"><code>0</code></td>
         <td class="classbit"><code>0</code></td>
         <td class="classbit"><code>1</code></td>
-        <td class="classbit"><code>1</code></td>
+        <td class="classbit"><code>0</code></td>
         <td class="classbit"><code>0</code></td>
         <td><code>r</code></td>
         <td><code>r</code></td>


### PR DESCRIPTION
The opcodes page documented **LOAD** as `100110rr` — identical to **STORE**. That's wrong: LOAD's bit 3 should be `0`, giving `100100rr`.

Verified against two sources:
- **Model** (`decoder.card.ts:58-64`): LOAD decodes as `!bit5 && bit4 && !bit3 && !bit2` → `100100rr`; STORE as `!bit5 && bit4 && bit3 && !bit2` → `100110rr`.
- **Official reference** ([relaycomputer.co.uk/pages/instructions](https://www.relaycomputer.co.uk/pages/instructions/)): LOAD `10010 0rr`, STORE `10011 0rr`.

One-bit change to the LOAD row so it reads `1 0 0 1 0 0 r r`. Build passes.

The rest of the page was cross-checked against the model and is accurate (GOTO, SETAB, MOV-8 incl. the full register map, MOV-16, STORE, INC-XY, HALT, ALU function codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)