### PR TITLE
View-layer improvements: cleanup, enabled LEDs, tests & CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# Keep dependencies current with weekly grouped Dependabot PRs. The CI workflow
+# (lint + build + test) gates every PR, so a bad bump is caught before merge.
+# Low-risk patch/minor bumps are grouped into one PR; majors get their own so
+# they can be reviewed properly.
+version: 2
+updates:
+  # --- npm packages ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "Etc/UTC"
+    cooldown:
+      # Wait 7 days after an upstream release before bumping — guards against
+      # immediately-yanked versions; cheap given the weekly cadence.
+      default-days: 7
+    open-pull-requests-limit: 5
+    ignore:
+      # relay-computer-model is published to GitHub Packages, not the public npm
+      # registry, so Dependabot can't resolve it here without a configured
+      # registry + token. It's the same author's package, bumped by hand on each
+      # release. To have Dependabot track it too: add a top-level `registries:`
+      # block (type: npm-registry, url: https://npm.pkg.github.com, token from a
+      # DEPENDABOT_GHPR_TOKEN secret with read:packages), reference it from this
+      # update via `registries: [...]`, and remove this ignore entry.
+      - dependency-name: "@paul80nd/relay-computer-model"
+    groups:
+      npm-patch-minor:
+        update-types: ["patch", "minor"]
+      npm-major:
+        update-types: ["major"]
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+
+  # --- GitHub Actions used in the workflows ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "Etc/UTC"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+# Clean install, lint, production build and unit tests on every push to main and
+# on pull requests (notably Dependabot's dependency-bump PRs, so a bad bump is
+# caught before it merges).
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Cancel a superseded in-flight run on the same ref (e.g. a Dependabot rebase or
+# a follow-up push) rather than letting both runs finish.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege token: read the repo, and read GitHub Packages — where the
+# @paul80nd/relay-computer-model dependency is published.
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [24.x] # keep in step with .nvmrc
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          # Route the @paul80nd scope to GitHub Packages and wire NODE_AUTH_TOKEN
+          # into the generated .npmrc so `npm ci` can resolve relay-computer-model.
+          # Public deps still come from the default npm registry.
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@paul80nd'
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm run lint
+      - run: npm run build
+      - run: npm test -- --watch=false

--- a/angular.json
+++ b/angular.json
@@ -90,6 +90,13 @@
               "src/**/*.html"
             ]
           }
+        },
+        "test": {
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "tsConfig": "tsconfig.spec.json",
+            "buildTarget": "relay-computer:build:development"
+          }
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
         "@typescript-eslint/parser": "^8.63.0",
         "angular-cli-ghpages": "3.1.0",
         "eslint": "^10.6.0",
-        "typescript": "6.0.3"
+        "jsdom": "30.0.0",
+        "typescript": "6.0.3",
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -811,6 +813,59 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.0.tgz",
+      "integrity": "sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -1104,6 +1159,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@clr/angular": {
       "version": "18.2.1",
       "resolved": "https://registry.npmjs.org/@clr/angular/-/angular-18.2.1.tgz",
@@ -1124,6 +1192,146 @@
       "resolved": "https://registry.npmjs.org/@clr/ui/-/ui-18.2.1.tgz",
       "integrity": "sha512-mrmBJ4jjBth+olMWPgqzB0dK4NLw+dnhwDYkyaeKagbfCvn6iekrbZ7pjDW0nsPkaiNlJBOqJswP15pIbs+Naw==",
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
@@ -1659,6 +1867,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gar/promise-retry": {
@@ -3857,6 +4083,24 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -4124,6 +4368,126 @@
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -4322,6 +4686,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -4381,6 +4755,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/body-parser": {
@@ -4589,6 +4973,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chardet": {
       "version": "2.2.0",
@@ -4861,6 +5255,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
@@ -4872,6 +5280,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -4891,6 +5328,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5100,6 +5544,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -5391,6 +5842,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5439,6 +5900,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -6082,6 +6553,19 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -6327,6 +6811,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6370,6 +6861,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-JQHfRGmmKmaZoUAvIgff5jjG/0SzTQlGz8c7t72KzBzo8ZULEjAjnYE0sNwBOUA4QtWwYE2xoYitg8NFsmiYxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.2.5",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.7.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6733,6 +7275,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -7329,6 +7878,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7659,6 +8222,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8173,6 +8743,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -8338,6 +8921,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -8530,6 +9120,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8539,6 +9136,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",
@@ -8622,6 +9226,13 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "7.5.19",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
@@ -8649,6 +9260,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -8665,6 +9293,36 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -8687,6 +9345,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-repeated": {
@@ -8804,6 +9488,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/universalify": {
@@ -8962,6 +9656,109 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -8984,6 +9781,41 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8998,6 +9830,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -9047,6 +9896,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "lint": "ng lint"
+    "lint": "ng lint",
+    "test": "ng test"
   },
   "private": true,
   "engines": {
@@ -48,6 +49,8 @@
     "@typescript-eslint/parser": "^8.63.0",
     "angular-cli-ghpages": "3.1.0",
     "eslint": "^10.6.0",
-    "typescript": "6.0.3"
+    "jsdom": "30.0.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -83,3 +83,14 @@
     </div>
   </div>
 </div>
+@if (notification(); as n) {
+  <!-- Docked to the bottom (fixed, out of flow) so showing it never reflows the
+       panel above — an invalid paste shouldn't make the whole UI jump. -->
+  <div class="alert-dock">
+    <clr-alert [clrAlertType]="n.type" [clrAlertAppLevel]="true" (clrAlertClosedChange)="dismiss()">
+      <clr-alert-item>
+        <span class="alert-text">{{ n.text }}</span>
+      </clr-alert-item>
+    </clr-alert>
+  </div>
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
 import { ComputerFactory, IComputer, IComputerFactory } from '@paul80nd/relay-computer-model';
+import { parseAssembledProgram } from './program-loader';
 import { ClrIconModule, ClrStopEscapePropagationDirective, ClrPopoverHostDirective, ClrDropdownModule, ClrConditionalModule, ClrTabsModule } from '@clr/angular';
 import { ComputerComponent } from './components/computer.component';
 import { DocumentationComponent } from './components/docs/docs.component';
@@ -34,19 +35,12 @@ export class AppComponent implements OnInit {
   loadFromClipboard() {
     navigator.clipboard.readText().then(
       text => {
-        if (/^[0-9a-f]*$/g.test(text)) {
-          const parts = text.match(/.{1,2}/g)
-          if (parts) {
-            const values = parts.map(p => parseInt(p, 16));
-            if (values.length > 2) {
-              const offset = values[0] + (values[1] << 8);
-              const prog = values.slice(2);
-              this.computer.yBackplane.memory.loadProgram(offset, prog);
-              return;
-            }
-          }
+        const program = parseAssembledProgram(text);
+        if (program) {
+          this.computer.yBackplane.memory.loadProgram(program.offset, program.prog);
+        } else {
+          alert(`Did not recognise clipboard contents as an assembled program.`);
         }
-        alert(`Did not recognise clipboard contents as an assembled program.`);
       }
     ).catch(error => {
       alert(`Cannot read clipboard text: ${error}`);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, DestroyRef, inject } from '@angular/core';
 
 import { ComputerFactory, IComputer, IComputerFactory } from '@paul80nd/relay-computer-model';
 import { parseAssembledProgram } from './program-loader';
@@ -18,14 +18,19 @@ export class AppComponent implements OnInit {
 
   computer!: IComputer;
 
+  private readonly destroyRef = inject(DestroyRef);
+
   ngOnInit() {
-    // Initially check if dark mode is enabled on system
-    const darkModeOn =
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches;
-    // If dark mode is enabled then directly switch to the dark-theme
-    if (darkModeOn) {
-      document.body.setAttribute("cds-theme", "dark");
+    // Follow the OS colour scheme, and keep following it while the app is open
+    // (toggling OS dark mode should flip the theme live, not only at load).
+    if (window.matchMedia) {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const applyTheme = (dark: boolean) =>
+        document.body.setAttribute("cds-theme", dark ? "dark" : "light");
+      applyTheme(mq.matches);
+      const onChange = (e: MediaQueryListEvent) => applyTheme(e.matches);
+      mq.addEventListener("change", onChange);
+      this.destroyRef.onDestroy(() => mq.removeEventListener("change", onChange));
     }
 
     const factory: IComputerFactory = new ComputerFactory();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, ChangeDetectionStrategy, DestroyRef, inject } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, DestroyRef, inject, signal } from '@angular/core';
 
 import { ComputerFactory, IComputer, IComputerFactory } from '@paul80nd/relay-computer-model';
 import { parseAssembledProgram } from './program-loader';
-import { ClrIconModule, ClrStopEscapePropagationDirective, ClrPopoverHostDirective, ClrDropdownModule, ClrConditionalModule, ClrTabsModule } from '@clr/angular';
+import { ClrIcon, ClrStopEscapePropagationDirective, ClrPopoverHostDirective, ClrDropdownModule, ClrConditionalModule, ClrTabsModule, ClrAlertModule } from '@clr/angular';
 import { ComputerComponent } from './components/computer.component';
 import { DocumentationComponent } from './components/docs/docs.component';
 import { ArchitectureDiagramComponent } from './components/archdiag/archdiag.component';
@@ -11,12 +11,30 @@ import { InstructionSetComponent } from './components/instrset/instrset.componen
 @Component({
     selector: 'rc-root',
     templateUrl: './app.component.html',
+    styles: `
+      .alert-dock {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+      }
+    `,
     changeDetection: ChangeDetectionStrategy.Eager,
-    imports: [ClrIconModule, ClrStopEscapePropagationDirective, ClrPopoverHostDirective, ClrDropdownModule, ClrConditionalModule, ComputerComponent, ClrTabsModule, DocumentationComponent, ArchitectureDiagramComponent, InstructionSetComponent]
+    imports: [ClrIcon, ClrStopEscapePropagationDirective, ClrPopoverHostDirective, ClrDropdownModule, ClrConditionalModule, ComputerComponent, ClrTabsModule, DocumentationComponent, ArchitectureDiagramComponent, InstructionSetComponent, ClrAlertModule]
 })
 export class AppComponent implements OnInit {
 
   computer!: IComputer;
+
+  // App-level alert banner shown in place of native alert(); null = hidden.
+  // A signal so setting it from the async clipboard callback schedules change
+  // detection under zoneless.
+  readonly notification = signal<{ type: 'warning' | 'danger'; text: string } | null>(null);
+
+  // Toast-style auto-dismiss timer for the banner above.
+  private dismissTimer?: ReturnType<typeof setTimeout>;
+  private static readonly DISMISS_MS = 6000;
 
   private readonly destroyRef = inject(DestroyRef);
 
@@ -33,6 +51,8 @@ export class AppComponent implements OnInit {
       this.destroyRef.onDestroy(() => mq.removeEventListener("change", onChange));
     }
 
+    this.destroyRef.onDestroy(() => clearTimeout(this.dismissTimer));
+
     const factory: IComputerFactory = new ComputerFactory();
     this.computer = factory.createComputer();
   }
@@ -44,13 +64,27 @@ export class AppComponent implements OnInit {
         if (program) {
           this.computer.yBackplane.memory.loadProgram(program.offset, program.prog);
         } else {
-          alert(`Did not recognise clipboard contents as an assembled program.`);
+          this.notify('warning', `Did not recognise clipboard contents as an assembled program.`);
         }
       }
     ).catch(error => {
-      alert(`Cannot read clipboard text: ${error}`);
+      this.notify('danger', `Cannot read clipboard text: ${error}`);
     });
 
+  }
+
+  // Show a toast-style banner and (re)arm its auto-dismiss.
+  private notify(type: 'warning' | 'danger', text: string): void {
+    clearTimeout(this.dismissTimer);
+    this.notification.set({ type, text });
+    this.dismissTimer = setTimeout(() => this.notification.set(null), AppComponent.DISMISS_MS);
+  }
+
+  // Dismiss the banner now (the X button) and cancel the pending auto-dismiss so
+  // a stale timer can't close a later message early.
+  dismiss(): void {
+    clearTimeout(this.dismissTimer);
+    this.notification.set(null);
   }
 
 }

--- a/src/app/components/lower_enclosure/cards/alu/card_alu_ctrl.component.svg
+++ b/src/app/components/lower_enclosure/cards/alu/card_alu_ctrl.component.svg
@@ -1,23 +1,23 @@
 <svg:g>
   <!-- Origin at bay top left -->
   <title>ALU Control Card</title>
-  <circle cx="19" cy="13" r="4" class="ledYellow" [class.on]="card().func.bit(f2Line)" />
-  <circle cx="29.25" cy="13" r="4" class="ledYellow" [class.on]="card().func.bit(f1Line)" />
-  <circle cx="39.5" cy="13" r="4" class="ledYellow" [class.on]="card().func.bit(f0Line)" />
-  <circle cx="49.75" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(shlLine)" />
-  <circle cx="60" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(notLine)" />
-  <circle cx="70.25" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(xorLine)" />
-  <circle cx="80.75" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(orrLine)" />
-  <circle cx="91.5" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(andLine)" />
-  <circle cx="102" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(incLine)" />
-  <circle cx="112.5" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(addLine)" />
-  <circle cx="123" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(clrLine)" />
+  <circle cx="19" cy="13" r="4" class="ledYellow" [class.on]="card().func.bit(AluFunctionClLines.F2)" />
+  <circle cx="29.25" cy="13" r="4" class="ledYellow" [class.on]="card().func.bit(AluFunctionClLines.F1)" />
+  <circle cx="39.5" cy="13" r="4" class="ledYellow" [class.on]="card().func.bit(AluFunctionClLines.F0)" />
+  <circle cx="49.75" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.SHL)" />
+  <circle cx="60" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.NOT)" />
+  <circle cx="70.25" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.XOR)" />
+  <circle cx="80.75" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.ORR)" />
+  <circle cx="91.5" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.AND)" />
+  <circle cx="102" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.INC)" />
+  <circle cx="112.5" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.ADD)" />
+  <circle cx="123" cy="13" r="4" class="ledGreen" [class.on]="card().operation.value.bit(AluOperationLines.CLR)" />
 
   <circle cx="175.5" cy="13" r="4" class="ledYellow" [class.on]="card().load" />
   <circle cx="185.75" cy="13" r="4" class="ledGreen" [class.on]="card().select" />
-  <circle cx="196" cy="13" r="4" class="ledRed" [class.on]="card().condition.value.bit(snLine)" />
-  <circle cx="206.25" cy="13" r="4" class="ledRed" [class.on]="card().condition.value.bit(cyLine)" />
-  <circle cx="216.5" cy="13" r="4" class="ledRed" [class.on]="card().condition.value.bit(ezLine)" />
+  <circle cx="196" cy="13" r="4" class="ledRed" [class.on]="card().condition.value.bit(ConditionLines.SN)" />
+  <circle cx="206.25" cy="13" r="4" class="ledRed" [class.on]="card().condition.value.bit(ConditionLines.CY)" />
+  <circle cx="216.5" cy="13" r="4" class="ledRed" [class.on]="card().condition.value.bit(ConditionLines.EZ)" />
 
 
   <svg:g transform="translate(-4,10)">

--- a/src/app/components/lower_enclosure/cards/alu/card_alu_ctrl.component.ts
+++ b/src/app/components/lower_enclosure/cards/alu/card_alu_ctrl.component.ts
@@ -14,22 +14,9 @@ import {
 
 export class CardAluControlComponent {
 
-  cyLine = ConditionLines.CY;
-  snLine = ConditionLines.SN;
-  ezLine = ConditionLines.EZ;
-
-  addLine: number = AluOperationLines.ADD;
-  incLine: number = AluOperationLines.INC;
-  shlLine: number = AluOperationLines.SHL;
-  andLine: number = AluOperationLines.AND;
-  orrLine: number = AluOperationLines.ORR;
-  xorLine: number = AluOperationLines.XOR;
-  notLine: number = AluOperationLines.NOT;
-  clrLine: number = AluOperationLines.CLR;
-
-  f2Line = AluFunctionClLines.F2;
-  f1Line = AluFunctionClLines.F1;
-  f0Line = AluFunctionClLines.F0;
+  protected readonly ConditionLines = ConditionLines;
+  protected readonly AluOperationLines = AluOperationLines;
+  protected readonly AluFunctionClLines = AluFunctionClLines;
 
   readonly card = input.required<IAluControlCard>();
 }

--- a/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
@@ -2,8 +2,8 @@
   <!-- Origin at bay top left -->
   <title>Control Card A</title>
 
-  <circle cx="19.5" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(at08Line)" />
-  <circle cx="29.75" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(at10Line)" />
+  <circle cx="19.5" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT08)" />
+  <circle cx="29.75" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT10)" />
   <!--
   <circle cx="40" cy="13" r="4" class="ledYellow" [class.on]="card.abort.bit(at12Line)" />
   <circle cx="50.5" cy="13" r="4" class="ledYellow" [class.on]="card.abort.bit(at14Line)" />
@@ -12,16 +12,16 @@
   <!--
     <circle cx="97" cy="13" r="4" class="ledYellow" />
     -->
-  <circle cx="107.5" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(merLine)" />
+  <circle cx="107.5" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.MER)" />
   <!--
     <circle cx="119" cy="13" r="4" class="ledYellow" />
     -->
-  <circle cx="128" cy="13" r="4" class="ledYellow" [class.on]="card().i2b.bit(i2bLine)" />
+  <circle cx="128" cy="13" r="4" class="ledYellow" [class.on]="card().i2b.bit(I2BLines.I2B)" />
 
 
-  <circle cx="174.5" cy="13" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(f2Line)" />
-  <circle cx="185" cy="13" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(f1Line)" />
-  <circle cx="195.5" cy="13" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(f0Line)"/>
+  <circle cx="174.5" cy="13" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(AluFunctionClLines.F2)" />
+  <circle cx="185" cy="13" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(AluFunctionClLines.F1)" />
+  <circle cx="195.5" cy="13" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(AluFunctionClLines.F0)"/>
 
 
   <svg:g transform="translate(-4,10)">

--- a/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
@@ -4,10 +4,8 @@
 
   <circle cx="19.5" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT08)" />
   <circle cx="29.75" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT10)" />
-  <!--
-  <circle cx="40" cy="13" r="4" class="ledYellow" [class.on]="card.abort.bit(at12Line)" />
-  <circle cx="50.5" cy="13" r="4" class="ledYellow" [class.on]="card.abort.bit(at14Line)" />
-   -->
+  <circle cx="40" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT12)" />
+  <circle cx="50.5" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT14)" />
 
   <!--
     <circle cx="97" cy="13" r="4" class="ledYellow" />

--- a/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
@@ -9,7 +9,7 @@
 
   <circle cx="97" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.B2M)" />
   <circle cx="107.5" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.MER)" />
-  <circle cx="119" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.MEW)" />
+  <circle cx="118" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.MEW)" />
   <circle cx="128" cy="13" r="4" class="ledYellow" [class.on]="card().i2b.bit(I2BLines.I2B)" />
 
 

--- a/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_a.component.svg
@@ -7,13 +7,9 @@
   <circle cx="40" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT12)" />
   <circle cx="50.5" cy="13" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT14)" />
 
-  <!--
-    <circle cx="97" cy="13" r="4" class="ledYellow" />
-    -->
+  <circle cx="97" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.B2M)" />
   <circle cx="107.5" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.MER)" />
-  <!--
-    <circle cx="119" cy="13" r="4" class="ledYellow" />
-    -->
+  <circle cx="119" cy="13" r="4" class="ledYellow" [class.on]="card().memory.bit(MemoryLines.MEW)" />
   <circle cx="128" cy="13" r="4" class="ledYellow" [class.on]="card().i2b.bit(I2BLines.I2B)" />
 
 

--- a/src/app/components/lower_enclosure/cards/control/card_control_a.component.ts
+++ b/src/app/components/lower_enclosure/cards/control/card_control_a.component.ts
@@ -11,16 +11,10 @@ import { AbortLines, I2BLines, MemoryLines, IControlCard, AluFunctionClLines } f
 
 export class CardControlAComponent {
 
-  at08Line = AbortLines.AT08;
-  at10Line = AbortLines.AT10;
-
-  f2Line = AluFunctionClLines.F2;
-  f1Line = AluFunctionClLines.F1;
-  f0Line = AluFunctionClLines.F0;
-
-  i2bLine = I2BLines.I2B;
-
-  merLine = MemoryLines.MER;
+  protected readonly AbortLines = AbortLines;
+  protected readonly AluFunctionClLines = AluFunctionClLines;
+  protected readonly I2BLines = I2BLines;
+  protected readonly MemoryLines = MemoryLines;
 
   readonly card = input.required<IControlCard>();
 

--- a/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
@@ -17,8 +17,8 @@
   <circle cx="70.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LJ2)" />
   <circle cx="91" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LM1)" />
   <circle cx="102" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LM2)" />
-  <circle cx="124" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LDX)" />
-  <circle cx="135" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LDY)" />
+  <circle cx="123" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LDX)" />
+  <circle cx="133.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LDY)" />
   <circle cx="144" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LXY)" />
   <circle cx="165" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LIN)" />
   <circle cx="185.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LIC)" />
@@ -27,11 +27,11 @@
   <circle cx="91" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SM1)" />
   <circle cx="102" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SM2)" />
   <circle cx="113" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEM)" />
-  <circle cx="124" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEX)" />
-  <circle cx="135" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEY)" />
+  <circle cx="123" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEX)" />
+  <circle cx="133.5" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEY)" />
   <circle cx="185.5" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SIC)" />
   <circle cx="195.75" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SPC)" />
-  <circle cx="146" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SXY)" />
+  <circle cx="144" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SXY)" />
   <!-- SDS / SAS live on card().sds (DataSwitchGateLines), not regJMXY — enable in a follow-up
     <circle cx="212" cy="18" r="4" class="ledGreen" />
     <circle cx="223" cy="18" r="4" class="ledGreen" />

--- a/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
@@ -17,28 +17,24 @@
   <circle cx="70.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LJ2)" />
   <circle cx="91" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LM1)" />
   <circle cx="102" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LM2)" />
-  <!--
-    <circle cx="135" cy="8.5" r="4" class="ledYellow" />
-    <circle cx="124" cy="8.5" r="4" class="ledYellow" />
-    -->
+  <circle cx="124" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LDX)" />
+  <circle cx="135" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LDY)" />
   <circle cx="144" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LXY)" />
   <circle cx="165" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LIN)" />
   <circle cx="185.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LIC)" />
   <circle cx="195.75" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LPC)" />
   <circle cx="81" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEJ)" />
-  <!--
-    <circle cx="91" cy="18" r="4" class="ledGreen" />
-    <circle cx="102" cy="18" r="4" class="ledGreen" />
-    <circle cx="113" cy="18" r="4" class="ledGreen" />
-    <circle cx="135" cy="18" r="4" class="ledGreen" />
-    <circle cx="124" cy="18" r="4" class="ledGreen" />
-    -->
+  <circle cx="91" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SM1)" />
+  <circle cx="102" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SM2)" />
+  <circle cx="113" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEM)" />
+  <circle cx="124" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEX)" />
+  <circle cx="135" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEY)" />
   <circle cx="185.5" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SIC)" />
   <circle cx="195.75" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SPC)" />
-  <!--
+  <circle cx="146" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SXY)" />
+  <!-- SDS / SAS live on card().sds (DataSwitchGateLines), not regJMXY — enable in a follow-up
     <circle cx="212" cy="18" r="4" class="ledGreen" />
     <circle cx="223" cy="18" r="4" class="ledGreen" />
-    <circle cx="146" cy="18" r="4" class="ledGreen" />
     -->
 
   <svg:g transform="translate(-4,10)">

--- a/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
@@ -2,30 +2,30 @@
   <!-- Origin at bay top left -720,-355 -->
   <title>Control Card B</title>
 
-  <circle cx="19.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(ldALine)" />
-  <circle cx="29.75" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(ldBLine)" />
-  <circle cx="40" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(ldCLine)" />
-  <circle cx="50.25" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(ldDLine)" />
-  <circle cx="19.5" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(selALine)" />
-  <circle cx="29.75" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(selBLine)" />
-  <circle cx="40" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(selCLine)" />
-  <circle cx="50.25" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(selDLine)" />
+  <circle cx="19.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(RegABCDLines.RLA)" />
+  <circle cx="29.75" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(RegABCDLines.RLB)" />
+  <circle cx="40" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(RegABCDLines.RLC)" />
+  <circle cx="50.25" cy="8.5" r="4" class="ledYellow" [class.on]="card().regABCD.bit(RegABCDLines.RLD)" />
+  <circle cx="19.5" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(RegABCDLines.RSA)" />
+  <circle cx="29.75" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(RegABCDLines.RSB)" />
+  <circle cx="40" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(RegABCDLines.RSC)" />
+  <circle cx="50.25" cy="18" r="4" class="ledGreen" [class.on]="card().regABCD.bit(RegABCDLines.RSD)" />
 
-  <circle cx="175.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(clLine)" />
+  <circle cx="175.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().aluFunc.bit(AluFunctionClLines.CL)" />
 
-  <circle cx="60.25" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(ldJ1Line)" />
-  <circle cx="70.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(ldJ2Line)" />
-  <circle cx="91" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(ldM1Line)" />
-  <circle cx="102" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(ldM2Line)" />
+  <circle cx="60.25" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LJ1)" />
+  <circle cx="70.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LJ2)" />
+  <circle cx="91" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LM1)" />
+  <circle cx="102" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LM2)" />
   <!--
     <circle cx="135" cy="8.5" r="4" class="ledYellow" />
     <circle cx="124" cy="8.5" r="4" class="ledYellow" />
     -->
-  <circle cx="144" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(ldXYLine)" />
-  <circle cx="165" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(linLine)" />
-  <circle cx="185.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(licLine)" />
-  <circle cx="195.75" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(lpcLine)" />
-  <circle cx="81" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(selJLine)" />
+  <circle cx="144" cy="8.5" r="4" class="ledYellow" [class.on]="card().regJMXY.bit(RegJMXYLines.LXY)" />
+  <circle cx="165" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LIN)" />
+  <circle cx="185.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LIC)" />
+  <circle cx="195.75" cy="8.5" r="4" class="ledYellow" [class.on]="card().auxReg.bit(RegAuxLines.LPC)" />
+  <circle cx="81" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SEJ)" />
   <!--
     <circle cx="91" cy="18" r="4" class="ledGreen" />
     <circle cx="102" cy="18" r="4" class="ledGreen" />
@@ -33,8 +33,8 @@
     <circle cx="135" cy="18" r="4" class="ledGreen" />
     <circle cx="124" cy="18" r="4" class="ledGreen" />
     -->
-  <circle cx="185.5" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(sicLine)" />
-  <circle cx="195.75" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(spcLine)" />
+  <circle cx="185.5" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SIC)" />
+  <circle cx="195.75" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SPC)" />
   <!--
     <circle cx="212" cy="18" r="4" class="ledGreen" />
     <circle cx="223" cy="18" r="4" class="ledGreen" />

--- a/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
+++ b/src/app/components/lower_enclosure/cards/control/card_control_b.component.svg
@@ -32,9 +32,15 @@
   <circle cx="185.5" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SIC)" />
   <circle cx="195.75" cy="18" r="4" class="ledGreen" [class.on]="card().auxReg.bit(RegAuxLines.SPC)" />
   <circle cx="144" cy="18" r="4" class="ledGreen" [class.on]="card().regJMXY.bit(RegJMXYLines.SXY)" />
-  <!-- SDS / SAS live on card().sds (DataSwitchGateLines), not regJMXY — enable in a follow-up
-    <circle cx="212" cy="18" r="4" class="ledGreen" />
-    <circle cx="223" cy="18" r="4" class="ledGreen" />
+  <!-- SDS / SAS: blocked on the model. These live on the control card's `sds` output
+       (DataSwitchGateLines), but IControlCard does not expose `sds` (only the concrete
+       ControlCard class does), so binding card().sds fails strictTemplates. To enable:
+       (1) add `sds: BitValue` to IControlCard in @paul80nd/relay-computer-model;
+       (2) import + expose DataSwitchGateLines here; then uncomment the label-aligned
+       circles below. NB: only SAS is ever driven by this card (SDS comes from the
+       control-switches front-panel card), so the SDS lamp will stay dark.
+    <circle cx="206" cy="18" r="4" class="ledGreen" [class.on]="card().sds.bit(DataSwitchGateLines.SDS)" />
+    <circle cx="216.5" cy="18" r="4" class="ledGreen" [class.on]="card().sds.bit(DataSwitchGateLines.SAS)" />
     -->
 
   <svg:g transform="translate(-4,10)">

--- a/src/app/components/lower_enclosure/cards/control/card_control_b.component.ts
+++ b/src/app/components/lower_enclosure/cards/control/card_control_b.component.ts
@@ -11,29 +11,10 @@ import { AluFunctionClLines, RegABCDLines, RegJMXYLines, RegAuxLines, IControlCa
 
 export class CardControlBComponent {
 
-  ldALine: number = RegABCDLines.RLA;
-  ldBLine: number = RegABCDLines.RLB;
-  ldCLine: number = RegABCDLines.RLC;
-  ldDLine: number = RegABCDLines.RLD;
-  selALine: number = RegABCDLines.RSA;
-  selBLine: number = RegABCDLines.RSB;
-  selCLine: number = RegABCDLines.RSC;
-  selDLine: number = RegABCDLines.RSD;
-
-  ldM1Line: number = RegJMXYLines.LM1;
-  ldM2Line: number = RegJMXYLines.LM2;
-  ldJ1Line: number = RegJMXYLines.LJ1;
-  ldJ2Line: number = RegJMXYLines.LJ2;
-  ldXYLine: number = RegJMXYLines.LXY;
-  selJLine: number = RegJMXYLines.SEJ;
-
-  clLine: number = AluFunctionClLines.CL;
-
-  licLine: number = RegAuxLines.LIC;
-  linLine: number = RegAuxLines.LIN;
-  lpcLine: number = RegAuxLines.LPC;
-  sicLine: number = RegAuxLines.SIC;
-  spcLine: number = RegAuxLines.SPC;
+  protected readonly RegABCDLines = RegABCDLines;
+  protected readonly RegJMXYLines = RegJMXYLines;
+  protected readonly AluFunctionClLines = AluFunctionClLines;
+  protected readonly RegAuxLines = RegAuxLines;
 
   readonly card = input.required<IControlCard>();
 

--- a/src/app/components/lower_enclosure/cards/decoder/card_decoder.component.svg
+++ b/src/app/components/lower_enclosure/cards/decoder/card_decoder.component.svg
@@ -2,24 +2,24 @@
   <!-- Origin at bay top left -->
   <title>Decoder</title>
 
-  <circle cx="34.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(gtoLine)"/>
+  <circle cx="34.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IGTO)"/>
 
-  <circle cx="56" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(setLine)"/>
+  <circle cx="56" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.ISET)"/>
 
-  <circle cx="76.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(mv8Line)"/>
+  <circle cx="76.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IMV8)"/>
 
   <!--
     <circle cx="97" cy="13" r="4" class="ledYellow"/>
     -->
 
-  <circle cx="118" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(aluLine)"/>
+  <circle cx="118" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IALU)"/>
 
   <!--
     <circle cx="141" cy="13" r="4" class="ledYellow"/>
 
     <circle cx="163" cy="13" r="4" class="ledYellow"/>
 -->
-  <circle cx="180" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(mscLine)"/>
+  <circle cx="180" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IMSC)"/>
   <!--
   <circle cx="207" cy="13" r="4" class="ledYellow"/>
     -->

--- a/src/app/components/lower_enclosure/cards/decoder/card_decoder.component.svg
+++ b/src/app/components/lower_enclosure/cards/decoder/card_decoder.component.svg
@@ -8,21 +8,15 @@
 
   <circle cx="76.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IMV8)"/>
 
-  <!--
-    <circle cx="97" cy="13" r="4" class="ledYellow"/>
-    -->
+  <circle cx="97" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IINC)"/>
 
   <circle cx="118" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IALU)"/>
 
-  <!--
-    <circle cx="141" cy="13" r="4" class="ledYellow"/>
+  <circle cx="138.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.ISTR)"/>
 
-    <circle cx="163" cy="13" r="4" class="ledYellow"/>
--->
+  <circle cx="159.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.ILOD)"/>
   <circle cx="180" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IMSC)"/>
-  <!--
-  <circle cx="207" cy="13" r="4" class="ledYellow"/>
-    -->
+  <circle cx="200.5" cy="13" r="4" class="ledYellow" [class.on]="card().operation.bit(OperationLines.IM16)"/>
 
   <svg:g transform="translate(-4,10)">
     <?xml version="1.0" encoding="utf-8" standalone="no"?>

--- a/src/app/components/lower_enclosure/cards/decoder/card_decoder.component.ts
+++ b/src/app/components/lower_enclosure/cards/decoder/card_decoder.component.ts
@@ -11,11 +11,7 @@ import { OperationLines, IDecoderCard } from '@paul80nd/relay-computer-model';
 
 export class CardDecoderComponent {
 
-  aluLine = OperationLines.IALU;
-  setLine = OperationLines.ISET;
-  mv8Line = OperationLines.IMV8;
-  gtoLine = OperationLines.IGTO;
-  mscLine = OperationLines.IMSC;
+  protected readonly OperationLines = OperationLines;
 
   readonly card = input.required<IDecoderCard>();
 

--- a/src/app/components/lower_enclosure/cards/memory/card_memory_a.component.svg
+++ b/src/app/components/lower_enclosure/cards/memory/card_memory_a.component.svg
@@ -3,9 +3,9 @@
   <title>Memory A</title>
 
   <circle cx="19" cy="13" r="4" class="ledYellow" [class.on]="card().memoryEnabled.value.bit(0)" />
-  <circle cx="29.5" cy="13" r="4" class="ledYellow" [class.on]="card().memoryCtrl.bit(merLine)" />
-  <circle cx="40" cy="13" r="4" class="ledYellow" [class.on]="card().memoryCtrl.bit(mewLine)" />
-  <circle cx="50.5" cy="13" r="4" class="ledYellow" [class.on]="card().memoryCtrl.bit(b2mLine)" />
+  <circle cx="29.5" cy="13" r="4" class="ledYellow" [class.on]="card().memoryCtrl.bit(MemoryLines.MER)" />
+  <circle cx="40" cy="13" r="4" class="ledYellow" [class.on]="card().memoryCtrl.bit(MemoryLines.MEW)" />
+  <circle cx="50.5" cy="13" r="4" class="ledYellow" [class.on]="card().memoryCtrl.bit(MemoryLines.B2M)" />
 
   <g (click)="card().toggleEnabled()" class="clickable" transform="rotate(90) translate(-215 -362) scale(0.5 0.75)">
     <path d="M 446 199.275 L 446 204.275 L 446 208.2241 L 446 209 L 446 209.27499 L 446.05586 209.27499 C 446.29495 210.92855 447.30146 212.53621 449.07537 213.80329 C 453.17585 216.73224 459.82403 216.73224 463.9245 213.80329 C 465.69842 212.53621 466.70492 210.92855 466.944 209.27499  L 466.99987 209.27499 L 466.99987 209 L 466.99987 204.275 L 466.99987 199.77209 L 466.99987 199.59587 C 467 199.55712 467.00008 199.51837 466.99987 199.47961 L 466.99987 199.275 L 466.99987 197 L 466.99987 194.7721 C 466.99891 194.65521 467.001 194.53824 466.9993 194.4213 L   466.99987 194.275 L 466.99518 194.275 C 466.9182 192.43126 465.89463 190.60394 463.9245 189.19671 C 459.82403 186.26776 453.17585 186.26776 449.07537 189.19671 C 447.10524 190.60394 446.08168 192.43126 446.0047 194.275 L 446 194.275 L 446 197 Z" fill="#bbb" />

--- a/src/app/components/lower_enclosure/cards/memory/card_memory_a.component.ts
+++ b/src/app/components/lower_enclosure/cards/memory/card_memory_a.component.ts
@@ -11,9 +11,7 @@ import { MemoryLines, IMemoryCard } from '@paul80nd/relay-computer-model';
 
 export class CardMemoryAComponent {
 
-  b2mLine = MemoryLines.B2M;
-  merLine = MemoryLines.MER;
-  mewLine = MemoryLines.MEW;
+  protected readonly MemoryLines = MemoryLines;
 
   readonly card = input.required<IMemoryCard>();
 

--- a/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_a.component.svg
+++ b/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_a.component.svg
@@ -8,7 +8,7 @@
     </g>
   }
 
-  <circle cx="29" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(at14Line)" />
+  <circle cx="29" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT14)" />
 
   <circle cx="185" cy="18" r="4" class="ledGreen" [class.on]="card().pulse.bit(11)" />
   <circle cx="185" cy="8.5" r="4" class="ledGreen" [class.on]="card().pulse.bit(12)" />

--- a/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_a.component.ts
+++ b/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_a.component.ts
@@ -10,7 +10,7 @@ import { AbortLines, ISequencerCard } from '@paul80nd/relay-computer-model';
 
 export class CardSequencerAComponent {
 
-  at14Line = AbortLines.AT14;
+  protected readonly AbortLines = AbortLines;
 
   readonly card = input.required<ISequencerCard>();
 }

--- a/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_b.component.svg
+++ b/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_b.component.svg
@@ -13,9 +13,9 @@
     </g>
   }
 
-  <circle cx="102" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(at08Line)" />
-  <circle cx="122.7" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(at10Line)" />
-  <circle cx="143.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(at12Line)" />
+  <circle cx="102" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT08)" />
+  <circle cx="122.7" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT10)" />
+  <circle cx="143.5" cy="8.5" r="4" class="ledYellow" [class.on]="card().abort.bit(AbortLines.AT12)" />
 
   <circle cx="165" cy="18" r="4" class="ledGreen" [class.on]="card().pulse.bit(0)" />
   <circle cx="165" cy="8.5" r="4" class="ledGreen" [class.on]="card().pulse.bit(1)" />

--- a/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_b.component.ts
+++ b/src/app/components/lower_enclosure/cards/sequencer/card_sequencer_b.component.ts
@@ -10,9 +10,7 @@ import { AbortLines, ISequencerCard } from '@paul80nd/relay-computer-model';
 
 export class CardSequencerBComponent {
 
-  at08Line = AbortLines.AT08;
-  at10Line = AbortLines.AT10;
-  at12Line = AbortLines.AT12;
+  protected readonly AbortLines = AbortLines;
 
   readonly card = input.required<ISequencerCard>();
 }

--- a/src/app/components/shared/leds/register_leds/register_16_leds.component.ts
+++ b/src/app/components/shared/leds/register_leds/register_16_leds.component.ts
@@ -1,11 +1,9 @@
 import { Component, input, ChangeDetectionStrategy } from '@angular/core';
-import { ByteLedsComponent } from './../byte_leds/byte_leds.component';
 import { IRegisterCardPart } from '@paul80nd/relay-computer-model';
 import { DoubleByteLedsComponent } from '../byte_leds/dbl_byte_leds.component';
 
 /* eslint-disable @angular-eslint/component-selector -- used in svg group */
 @Component({
-  providers: [ByteLedsComponent],
   selector: '[rc-register-16-leds]',
   templateUrl: 'register_16_leds.component.svg',
   changeDetection: ChangeDetectionStrategy.Eager,

--- a/src/app/components/shared/leds/register_leds/register_816_leds.component.ts
+++ b/src/app/components/shared/leds/register_leds/register_816_leds.component.ts
@@ -1,15 +1,13 @@
 import { Component, input, ChangeDetectionStrategy } from '@angular/core';
-import { ByteLedsComponent } from './../byte_leds/byte_leds.component';
 import { IRegisterYCardPart } from '@paul80nd/relay-computer-model';
-import { ByteLedsComponent as ByteLedsComponent_1 } from '../byte_leds/byte_leds.component';
+import { ByteLedsComponent } from '../byte_leds/byte_leds.component';
 
 /* eslint-disable @angular-eslint/component-selector -- used in svg group */
 @Component({
-  providers: [ByteLedsComponent],
   selector: '[rc-register-816-leds]',
   templateUrl: 'register_816_leds.component.svg',
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ByteLedsComponent_1]
+  imports: [ByteLedsComponent]
 })
 
 export class Register816LedsComponent {

--- a/src/app/components/shared/leds/register_leds/register_leds.component.ts
+++ b/src/app/components/shared/leds/register_leds/register_leds.component.ts
@@ -1,15 +1,13 @@
 import { Component, input, ChangeDetectionStrategy } from '@angular/core';
-import { ByteLedsComponent } from './../byte_leds/byte_leds.component';
 import { IRegisterCardPart } from '@paul80nd/relay-computer-model'
-import { ByteLedsComponent as ByteLedsComponent_1 } from '../byte_leds/byte_leds.component';
+import { ByteLedsComponent } from '../byte_leds/byte_leds.component';
 
 /* eslint-disable @angular-eslint/component-selector -- used in svg group */
 @Component({
-  providers: [ByteLedsComponent],
   selector: '[rc-register-leds]',
   templateUrl: 'register_leds.component.svg',
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ByteLedsComponent_1]
+  imports: [ByteLedsComponent]
 })
 
 export class RegisterLedsComponent {

--- a/src/app/components/state_view/dec.pipe.spec.ts
+++ b/src/app/components/state_view/dec.pipe.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { DecPipe } from './dec.pipe';
+
+describe('DecPipe', () => {
+  const pipe = new DecPipe();
+
+  describe('unsigned (neg = false)', () => {
+    it('renders the plain decimal value regardless of the top bit', () => {
+      expect(pipe.transform(200, '2', false)).toBe('200');
+      expect(pipe.transform(255, '2', false)).toBe('255');
+      expect(pipe.transform(40000, '4', false)).toBe('40000');
+    });
+
+    it('renders zero as "0"', () => {
+      expect(pipe.transform(0, '2', false)).toBe('0');
+    });
+  });
+
+  describe("signed 8-bit (len '2', neg = true)", () => {
+    it('leaves values below the sign bit positive', () => {
+      expect(pipe.transform(0, '2', true)).toBe('0');
+      expect(pipe.transform(1, '2', true)).toBe('1');
+      expect(pipe.transform(127, '2', true)).toBe('127'); // max positive
+    });
+
+    it("two's-complements values at or above the sign bit", () => {
+      expect(pipe.transform(128, '2', true)).toBe('-128'); // min negative
+      expect(pipe.transform(200, '2', true)).toBe('-56');
+      expect(pipe.transform(255, '2', true)).toBe('-1');
+    });
+  });
+
+  describe("signed 16-bit (len '4', neg = true)", () => {
+    it('leaves values below the sign bit positive', () => {
+      expect(pipe.transform(32767, '4', true)).toBe('32767'); // max positive
+    });
+
+    it("two's-complements values at or above the sign bit", () => {
+      expect(pipe.transform(32768, '4', true)).toBe('-32768'); // min negative
+      expect(pipe.transform(40000, '4', true)).toBe('-25536');
+      expect(pipe.transform(65535, '4', true)).toBe('-1');
+    });
+  });
+
+  // NB: the sign/mask maths uses bitwise operators (32-bit signed in JS), so this
+  // pipe only supports widths up to len '4' (16-bit). len '8' (32-bit) is not
+  // exercised by the app and is not covered here — see TODO.md.
+});

--- a/src/app/components/state_view/hex.pipe.spec.ts
+++ b/src/app/components/state_view/hex.pipe.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { HexPipe } from './hex.pipe';
+
+describe('HexPipe', () => {
+  const pipe = new HexPipe();
+
+  it('formats and upper-cases a value to the requested digit width', () => {
+    expect(pipe.transform(0x0a, '4')).toBe('000A');
+    expect(pipe.transform(0xabcd, '4')).toBe('ABCD');
+    expect(pipe.transform(255, '2')).toBe('FF');
+  });
+
+  it('renders zero as a padded run of zeros', () => {
+    expect(pipe.transform(0, '2')).toBe('00');
+    expect(pipe.transform(0, '4')).toBe('0000');
+  });
+
+  it('left-pads shorter values to the requested width', () => {
+    expect(pipe.transform(1, '2')).toBe('01');
+    expect(pipe.transform(0x0f, '4')).toBe('000F');
+  });
+
+  it('does not pad when the value already fills the width', () => {
+    expect(pipe.transform(0xff, '2')).toBe('FF');
+    expect(pipe.transform(0xabcd, '4')).toBe('ABCD');
+  });
+
+  // Characterisation of current behaviour / known limitations (see TODO.md).
+  describe('current behaviour (documented quirks)', () => {
+    it('does NOT truncate values wider than the requested width', () => {
+      // A value that overflows the field is rendered in full rather than masked.
+      expect(pipe.transform(0x1000, '2')).toBe('1000');
+    });
+
+    it('does not special-case negative numbers (renders a signed hex string)', () => {
+      // In practice registers carry unsigned values, so this path is not exercised.
+      expect(pipe.transform(-1, '2')).toBe('-1');
+    });
+  });
+});

--- a/src/app/components/state_view/state_view.component.spec.ts
+++ b/src/app/components/state_view/state_view.component.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StateViewComponent } from './state_view.component';
+
+// Memory paging clamps offset to [0, 0xFF00] (a 256-byte page over 64KB memory).
+// The template stub avoids rendering the SVG, which reads the required computer
+// input; the paging methods under test don't touch it.
+describe('StateViewComponent paging', () => {
+  let fixture: ComponentFixture<StateViewComponent>;
+  let component: StateViewComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [StateViewComponent] })
+      .overrideComponent(StateViewComponent, { set: { template: '' } });
+    fixture = TestBed.createComponent(StateViewComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('advances a page at a time', () => {
+    expect(component.offset).toBe(0);
+    component.nextPage();
+    expect(component.offset).toBe(0x100);
+    component.nextPage();
+    expect(component.offset).toBe(0x200);
+  });
+
+  it('steps back a page at a time', () => {
+    component.offset = 0x300;
+    component.prevPage();
+    expect(component.offset).toBe(0x200);
+  });
+
+  it('clamps prevPage at zero (no negative offset)', () => {
+    component.offset = 0;
+    component.prevPage();
+    expect(component.offset).toBe(0);
+  });
+
+  it('clamps nextPage at the last page (0xFF00)', () => {
+    component.offset = 0xff00;
+    component.nextPage();
+    expect(component.offset).toBe(0xff00);
+  });
+
+  it('does not overshoot the ceiling from the penultimate page', () => {
+    component.offset = 0xfe00;
+    component.nextPage();
+    expect(component.offset).toBe(0xff00);
+    component.nextPage();
+    expect(component.offset).toBe(0xff00);
+  });
+});

--- a/src/app/components/state_view/state_view.component.svg
+++ b/src/app/components/state_view/state_view.component.svg
@@ -35,15 +35,15 @@
     <path d="M 225 185 L 225 115" fill="none" stroke="#999999" stroke-miterlimit="10" stroke-dasharray="3 3" />
 
     <!-- ALU Flags -->
-    <g [class.alu-active]="computer().zBackplane.aluControl.condition.value.bit(snLine)">
+    <g [class.alu-active]="computer().zBackplane.aluControl.condition.value.bit(ConditionLines.SN)">
       <rect x="265" y="145" width="45" height="39" fill="none" stroke="#999999" />
       <text x="288" y="174" class="alu-label" text-anchor="middle">S</text>
     </g>
-    <g [class.alu-active]="computer().zBackplane.aluControl.condition.value.bit(cyLine)">
+    <g [class.alu-active]="computer().zBackplane.aluControl.condition.value.bit(ConditionLines.CY)">
       <rect x="323" y="145" width="45" height="39" fill="none" stroke="#999999" />
       <text x="346" y="174" class="alu-label" text-anchor="middle">C</text>
     </g>
-    <g [class.alu-active]="computer().zBackplane.aluControl.condition.value.bit(ezLine)">
+    <g [class.alu-active]="computer().zBackplane.aluControl.condition.value.bit(ConditionLines.EZ)">
       <rect x="380" y="145" width="45" height="39" fill="none" stroke="#999999" />
       <text x="403" y="174" class="alu-label" text-anchor="middle">Z</text>
     </g>

--- a/src/app/components/state_view/state_view.component.ts
+++ b/src/app/components/state_view/state_view.component.ts
@@ -15,9 +15,7 @@ import { HexPipe } from './hex.pipe';
 
 export class StateViewComponent {
 
-  cyLine = ConditionLines.CY;
-  snLine = ConditionLines.SN;
-  ezLine = ConditionLines.EZ;
+  protected readonly ConditionLines = ConditionLines;
 
   offset = 0;
   memoryDec = false;

--- a/src/app/components/state_view/state_view.component.ts
+++ b/src/app/components/state_view/state_view.component.ts
@@ -17,6 +17,12 @@ export class StateViewComponent {
 
   protected readonly ConditionLines = ConditionLines;
 
+  // One page is 256 bytes (16x16). Memory is 64KB, so the last page starts at
+  // 0xFF00. The template already hides the paging arrows at these bounds; the
+  // clamp keeps offset valid regardless of how nextPage/prevPage are called.
+  private static readonly PAGE = 0x100;
+  private static readonly MAX_OFFSET = 0x10000 - StateViewComponent.PAGE;
+
   offset = 0;
   memoryDec = false;
 
@@ -27,9 +33,9 @@ export class StateViewComponent {
   }
 
   nextPage() {
-    this.offset += 0x100;
+    this.offset = Math.min(this.offset + StateViewComponent.PAGE, StateViewComponent.MAX_OFFSET);
   }
   prevPage() {
-    this.offset -= 0x100;
+    this.offset = Math.max(this.offset - StateViewComponent.PAGE, 0);
   }
 }

--- a/src/app/components/upper_enclosure/control_switches/control_switches.component.spec.ts
+++ b/src/app/components/upper_enclosure/control_switches/control_switches.component.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IControlSwitchesCard } from '@paul80nd/relay-computer-model';
+import { ControlSwitchesComponent } from './control_switches.component';
+
+// The front-panel momentary switches debounce for 500ms: a flip fires the model
+// call, latches a transient signal, and re-arms only after a timeout. These tests
+// drive the class directly (no template render) with fake timers + a mock card.
+describe('ControlSwitchesComponent', () => {
+  let fixture: ComponentFixture<ControlSwitchesComponent>;
+  let component: ControlSwitchesComponent;
+  let card: {
+    deposit: ReturnType<typeof vi.fn>;
+    depositNext: ReturnType<typeof vi.fn>;
+    examine: ReturnType<typeof vi.fn>;
+    examineNext: ReturnType<typeof vi.fn>;
+    loadAddr: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    card = {
+      deposit: vi.fn(),
+      depositNext: vi.fn(),
+      examine: vi.fn(),
+      examineNext: vi.fn(),
+      loadAddr: vi.fn(),
+    };
+
+    // Stub the SVG template: this builder auto-detects changes, and the real
+    // template renders child switches that need their own inputs. We only
+    // exercise the component class (the debounce state machine).
+    TestBed.configureTestingModule({ imports: [ControlSwitchesComponent] })
+      .overrideComponent(ControlSwitchesComponent, { set: { template: '' } });
+    fixture = TestBed.createComponent(ControlSwitchesComponent);
+    fixture.componentRef.setInput('card', card as unknown as IControlSwitchesCard);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('deposit', () => {
+    it('a down-flip fires deposit() and latches the deposit signal', () => {
+      component.changeDeposit(false);
+
+      expect(card.deposit).toHaveBeenCalledTimes(1);
+      expect(card.depositNext).not.toHaveBeenCalled();
+      expect(component.deposit()).toBe(true);
+      expect(component.depositNext()).toBe(false);
+    });
+
+    it('an up-flip fires depositNext() and latches the depositNext signal', () => {
+      component.changeDeposit(true);
+
+      expect(card.depositNext).toHaveBeenCalledTimes(1);
+      expect(card.deposit).not.toHaveBeenCalled();
+      expect(component.deposit()).toBe(false);
+      expect(component.depositNext()).toBe(true);
+    });
+
+    it('ignores a second flip while still latched (debounce)', () => {
+      component.changeDeposit(false);
+      component.changeDeposit(false); // repeat within the window
+      component.changeDeposit(true);  // opposite direction, still within the window
+
+      expect(card.deposit).toHaveBeenCalledTimes(1);
+      expect(card.depositNext).not.toHaveBeenCalled();
+    });
+
+    it('re-arms after the 500ms window so a later flip fires again', () => {
+      component.changeDeposit(false);
+      vi.advanceTimersByTime(500);
+
+      expect(component.deposit()).toBe(false);
+      expect(component.depositNext()).toBe(false);
+
+      component.changeDeposit(false);
+      expect(card.deposit).toHaveBeenCalledTimes(2);
+    });
+
+    it('stays latched just before the window elapses', () => {
+      component.changeDeposit(false);
+      vi.advanceTimersByTime(499);
+
+      expect(component.deposit()).toBe(true);
+      component.changeDeposit(false);
+      expect(card.deposit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('examine', () => {
+    it('a down-flip fires examine() and an up-flip fires examineNext()', () => {
+      component.changeExamine(false);
+      expect(card.examine).toHaveBeenCalledTimes(1);
+      expect(component.examine()).toBe(true);
+
+      // Still latched, so the up-flip is ignored until the window elapses.
+      component.changeExamine(true);
+      expect(card.examineNext).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(500);
+      component.changeExamine(true);
+      expect(card.examineNext).toHaveBeenCalledTimes(1);
+      expect(component.examineNext()).toBe(true);
+    });
+  });
+
+  describe('loadAddr', () => {
+    it('fires once, debounces a repeat, then re-arms after 500ms', () => {
+      component.changeLoadAddr();
+      component.changeLoadAddr();
+
+      expect(card.loadAddr).toHaveBeenCalledTimes(1);
+      expect(component.loadAddr()).toBe(true);
+
+      vi.advanceTimersByTime(500);
+      expect(component.loadAddr()).toBe(false);
+
+      component.changeLoadAddr();
+      expect(card.loadAddr).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/app/components/upper_enclosure/displays/display_a/display_a.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a.component.svg
@@ -7,26 +7,26 @@
 
         <g rc-display-a-a2a [part]="card().a2abReg" [valueIn]="card().a2abRegIn" transform="translate(107.9999,9.999977)"></g>
 
-        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['ld','Inst']" [color]="'Yellow'" [bitTarget]="linLine" transform="translate(9.999992 61.999977)"></g>
-        <g rc-tact-switch [part]="card().a1cCl" [valueIn]="card().a1cClIn" [description]="['ld','Cond']" [color]="'Yellow'" [bitTarget]="clLine" transform="translate(32.999992 61.999977)"></g>
-        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['ld','INC']" [color]="'Yellow'" [bitTarget]="licLine" transform="translate(55.999992 61.999977)"></g>
-        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['sel','INC']" [color]="'Green'" [bitTarget]="sicLine" transform="translate(55.999992 84.999977)"></g>
-        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['ld','PC']" [color]="'Yellow'" [bitTarget]="lpcLine" transform="translate(78.99999 61.999977)"></g>
-        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['sel','PC']" [color]="'Green'" [bitTarget]="spcLine" transform="translate(78.99999 84.999977)"></g>
+        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['ld','Inst']" [color]="'Yellow'" [bitTarget]="RegAuxLines.LIN" transform="translate(9.999992 61.999977)"></g>
+        <g rc-tact-switch [part]="card().a1cCl" [valueIn]="card().a1cClIn" [description]="['ld','Cond']" [color]="'Yellow'" [bitTarget]="AluFunctionClLines.CL" transform="translate(32.999992 61.999977)"></g>
+        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['ld','INC']" [color]="'Yellow'" [bitTarget]="RegAuxLines.LIC" transform="translate(55.999992 61.999977)"></g>
+        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['sel','INC']" [color]="'Green'" [bitTarget]="RegAuxLines.SIC" transform="translate(55.999992 84.999977)"></g>
+        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['ld','PC']" [color]="'Yellow'" [bitTarget]="RegAuxLines.LPC" transform="translate(78.99999 61.999977)"></g>
+        <g rc-tact-switch [part]="card().a1cAuxReg" [valueIn]="card().a1cAuxRegIn" [description]="['sel','PC']" [color]="'Green'" [bitTarget]="RegAuxLines.SPC" transform="translate(78.99999 84.999977)"></g>
 
         <g rc-display-a-a2b [part]="card().a2abReg" [valueIn]="card().a2abRegIn" transform="translate(107.9999,61.999977)"></g>
 
-        <g rc-tact-switch [part]="card().a2b" [valueIn]="card().a2bIn" [description]="['sel','DS']" [color]="'Green'" [bitTarget]="sdsLine" transform="translate(181.99999,84.999977)"></g>
-        <g rc-tact-switch [part]="card().a2b" [valueIn]="card().a2bIn" [description]="['sel','AS']" [color]="'Green'" [bitTarget]="sasLine" transform="translate(204.99999 84.999977)"></g>
+        <g rc-tact-switch [part]="card().a2b" [valueIn]="card().a2bIn" [description]="['sel','DS']" [color]="'Green'" [bitTarget]="DataSwitchGateLines.SDS" transform="translate(181.99999,84.999977)"></g>
+        <g rc-tact-switch [part]="card().a2b" [valueIn]="card().a2bIn" [description]="['sel','AS']" [color]="'Green'" [bitTarget]="DataSwitchGateLines.SAS" transform="translate(204.99999 84.999977)"></g>
 
-        <g rc-tact-switch [part]="card().a1bClock" [valueIn]="card().a1bClockIn" [description]="['CLK']" [color]="'Red'" [bitTarget]="clkLine" transform="translate(9.999992,113.99998)"></g>
-        <g rc-tact-switch [part]="card().a1bI2b" [valueIn]="card().a1bI2bIn" [description]="['I2B']" [color]="'Green'" [bitTarget]="i2bLine" transform="translate(9.999992,136.99998)"></g>
+        <g rc-tact-switch [part]="card().a1bClock" [valueIn]="card().a1bClockIn" [description]="['CLK']" [color]="'Red'" [bitTarget]="ClockLines.CLK" transform="translate(9.999992,113.99998)"></g>
+        <g rc-tact-switch [part]="card().a1bI2b" [valueIn]="card().a1bI2bIn" [description]="['I2B']" [color]="'Green'" [bitTarget]="I2BLines.I2B" transform="translate(9.999992,136.99998)"></g>
 
         <g rc-display-a-a2c [part]="card().a2c" [valueIn]="card().a2cIn" transform="translate(135.99999 113.99998)"></g>
 
-        <g rc-tact-switch [part]="card().a1bMemory" [valueIn]="card().a1bMemoryIn" [description]="['B2M']" [color]="'Yellow'" [bitTarget]="b2mLine" transform="translate(55.999992,113.99998)"></g>
-        <g rc-tact-switch [part]="card().a1bMemory" [valueIn]="card().a1bMemoryIn" [description]="['MW']" [color]="'Yellow'" [bitTarget]="mewLine" transform="translate(78.99999,113.99998)"></g>
-        <g rc-tact-switch [part]="card().a1bMemory" [valueIn]="card().a1bMemoryIn" [description]="['MR']" [color]="'Green'" [bitTarget]="merLine" transform="translate(78.99999,136.99998)"></g>
+        <g rc-tact-switch [part]="card().a1bMemory" [valueIn]="card().a1bMemoryIn" [description]="['B2M']" [color]="'Yellow'" [bitTarget]="MemoryLines.B2M" transform="translate(55.999992,113.99998)"></g>
+        <g rc-tact-switch [part]="card().a1bMemory" [valueIn]="card().a1bMemoryIn" [description]="['MW']" [color]="'Yellow'" [bitTarget]="MemoryLines.MEW" transform="translate(78.99999,113.99998)"></g>
+        <g rc-tact-switch [part]="card().a1bMemory" [valueIn]="card().a1bMemoryIn" [description]="['MR']" [color]="'Green'" [bitTarget]="MemoryLines.MER" transform="translate(78.99999,136.99998)"></g>
     </g>
 </g>
 </svg:g>

--- a/src/app/components/upper_enclosure/displays/display_a/display_a.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a.component.ts
@@ -20,21 +20,12 @@ import { DisplayAA2CComponent } from './display_a_a2c.component';
 })
 export class DisplayAComponent {
 
-  clLine: number = AluFunctionClLines.CL;
-  licLine: number = RegAuxLines.LIC;
-  linLine: number = RegAuxLines.LIN;
-  lpcLine: number = RegAuxLines.LPC;
-  sicLine: number = RegAuxLines.SIC;
-  spcLine: number = RegAuxLines.SPC;
-
-  sdsLine: number = DataSwitchGateLines.SDS;
-  sasLine: number = DataSwitchGateLines.SAS;
-
-  clkLine: number = ClockLines.CLK;
-  i2bLine: number = I2BLines.I2B;
-  b2mLine: number = MemoryLines.B2M;
-  merLine: number = MemoryLines.MER;
-  mewLine: number = MemoryLines.MEW;
+  protected readonly AluFunctionClLines = AluFunctionClLines;
+  protected readonly RegAuxLines = RegAuxLines;
+  protected readonly DataSwitchGateLines = DataSwitchGateLines;
+  protected readonly ClockLines = ClockLines;
+  protected readonly I2BLines = I2BLines;
+  protected readonly MemoryLines = MemoryLines;
 
   readonly card = input.required<IDisplayACard>();
 

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a1a.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a1a.component.svg
@@ -1,19 +1,19 @@
 <svg:g>
     <!-- Origin at top left switch -->
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','A']" [color]="'Yellow'" [bitTarget]="ldALine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','A']" [color]="'Yellow'" [bitTarget]="RegABCDLines.RLA"
         transform="translate(0,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','B']" [color]="'Yellow'" [bitTarget]="ldBLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','B']" [color]="'Yellow'" [bitTarget]="RegABCDLines.RLB"
         transform="translate(23,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','C']" [color]="'Yellow'" [bitTarget]="ldCLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','C']" [color]="'Yellow'" [bitTarget]="RegABCDLines.RLC"
         transform="translate(46,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','D']" [color]="'Yellow'" [bitTarget]="ldDLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','D']" [color]="'Yellow'" [bitTarget]="RegABCDLines.RLD"
         transform="translate(69,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','A']" [color]="'Green'" [bitTarget]="selALine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','A']" [color]="'Green'" [bitTarget]="RegABCDLines.RSA"
         transform="translate(0,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','B']" [color]="'Green'" [bitTarget]="selBLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','B']" [color]="'Green'" [bitTarget]="RegABCDLines.RSB"
         transform="translate(23,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','C']" [color]="'Green'" [bitTarget]="selCLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','C']" [color]="'Green'" [bitTarget]="RegABCDLines.RSC"
         transform="translate(46,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','D']" [color]="'Green'" [bitTarget]="selDLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','D']" [color]="'Green'" [bitTarget]="RegABCDLines.RSD"
         transform="translate(69,23)"></g>
 </svg:g>

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a1a.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a1a.component.ts
@@ -12,14 +12,7 @@ import { TactileSwitchComponent } from '../../../shared/switches/tact_switch/tac
 })
 export class DisplayAA1AComponent {
 
-  ldALine: number = RegABCDLines.RLA;
-  ldBLine: number = RegABCDLines.RLB;
-  ldCLine: number = RegABCDLines.RLC;
-  ldDLine: number = RegABCDLines.RLD;
-  selALine: number = RegABCDLines.RSA;
-  selBLine: number = RegABCDLines.RSB;
-  selCLine: number = RegABCDLines.RSC;
-  selDLine: number = RegABCDLines.RSD;
+  protected readonly RegABCDLines = RegABCDLines;
 
   readonly part = input.required<CardOutput>();
   readonly valueIn = input.required<BitValue>();

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a2a.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a2a.component.svg
@@ -1,19 +1,19 @@
 <svg:g>
     <!-- Origin at top left switch -->
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','M1']" [color]="'Yellow'" [bitTarget]="ldM1Line"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','M1']" [color]="'Yellow'" [bitTarget]="RegJMXYLines.LM1"
         transform="translate(0,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','M2']" [color]="'Yellow'" [bitTarget]="ldM2Line"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','M2']" [color]="'Yellow'" [bitTarget]="RegJMXYLines.LM2"
         transform="translate(23,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','J1']" [color]="'Yellow'" [bitTarget]="ldJ1Line"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','J1']" [color]="'Yellow'" [bitTarget]="RegJMXYLines.LJ1"
         transform="translate(74,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','J2']" [color]="'Yellow'" [bitTarget]="ldJ2Line"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','J2']" [color]="'Yellow'" [bitTarget]="RegJMXYLines.LJ2"
         transform="translate(97,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','M1']" [color]="'Green'" [bitTarget]="selM1Line"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','M1']" [color]="'Green'" [bitTarget]="RegJMXYLines.SM1"
         transform="translate(0,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','M2']" [color]="'Green'" [bitTarget]="selM2Line"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','M2']" [color]="'Green'" [bitTarget]="RegJMXYLines.SM2"
         transform="translate(23,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','M']" [color]="'Green'" [bitTarget]="selMLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','M']" [color]="'Green'" [bitTarget]="RegJMXYLines.SEM"
         transform="translate(46,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','J']" [color]="'Green'" [bitTarget]="selJLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','J']" [color]="'Green'" [bitTarget]="RegJMXYLines.SEJ"
         transform="translate(97,23)"></g>
 </svg:g>

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a2a.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a2a.component.ts
@@ -12,14 +12,7 @@ import { TactileSwitchComponent } from '../../../shared/switches/tact_switch/tac
 })
 export class DisplayAA2AComponent {
 
-  ldM1Line: number = RegJMXYLines.LM1;
-  ldM2Line: number = RegJMXYLines.LM2;
-  ldJ1Line: number = RegJMXYLines.LJ1;
-  ldJ2Line: number = RegJMXYLines.LJ2;
-  selM1Line: number = RegJMXYLines.SM1;
-  selM2Line: number = RegJMXYLines.SM2;
-  selMLine: number = RegJMXYLines.SEM;
-  selJLine: number = RegJMXYLines.SEJ;
+  protected readonly RegJMXYLines = RegJMXYLines;
 
   readonly part = input.required<CardOutput>();
   readonly valueIn = input.required<BitValue>();

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a2b.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a2b.component.svg
@@ -1,15 +1,15 @@
 <svg:g>
     <!-- Origin at top left switch -->
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','X']" [color]="'Yellow'" [bitTarget]="ldXLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','X']" [color]="'Yellow'" [bitTarget]="RegJMXYLines.LDX"
         transform="translate(0,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','Y']" [color]="'Yellow'" [bitTarget]="ldYLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','Y']" [color]="'Yellow'" [bitTarget]="RegJMXYLines.LDY"
         transform="translate(23,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','XY']" [color]="'Yellow'" [bitTarget]="ldXYLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ld','XY']" [color]="'Yellow'" [bitTarget]="RegJMXYLines.LXY"
         transform="translate(46,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','X']" [color]="'Green'" [bitTarget]="selXLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','X']" [color]="'Green'" [bitTarget]="RegJMXYLines.SEX"
         transform="translate(0,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','Y']" [color]="'Green'" [bitTarget]="selYLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','Y']" [color]="'Green'" [bitTarget]="RegJMXYLines.SEY"
         transform="translate(23,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','XY']" [color]="'Green'" [bitTarget]="selXYLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['sel','XY']" [color]="'Green'" [bitTarget]="RegJMXYLines.SXY"
         transform="translate(46,23)"></g>
 </svg:g>

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a2b.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a2b.component.ts
@@ -12,12 +12,7 @@ import { TactileSwitchComponent } from '../../../shared/switches/tact_switch/tac
 })
 export class DisplayAA2BComponent {
 
-  ldXLine: number = RegJMXYLines.LDX;
-  ldYLine: number = RegJMXYLines.LDY;
-  ldXYLine: number = RegJMXYLines.LXY;
-  selXLine: number = RegJMXYLines.SEX;
-  selYLine: number = RegJMXYLines.SEY;
-  selXYLine: number = RegJMXYLines.SXY;
+  protected readonly RegJMXYLines = RegJMXYLines;
 
   readonly part = input.required<CardOutput>();
   readonly valueIn = input.required<BitValue>();

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a2c.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a2c.component.svg
@@ -1,17 +1,17 @@
 <svg:g>
     <!-- Origin at top left gap for switch -->
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ADD']" [color]="'Yellow'" [bitTarget]="addLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['ADD']" [color]="'Yellow'" [bitTarget]="AluOperationLines.ADD"
         transform="translate(23,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['INC']" [color]="'Yellow'" [bitTarget]="incLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['INC']" [color]="'Yellow'" [bitTarget]="AluOperationLines.INC"
         transform="translate(46,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['SHL']" [color]="'Yellow'" [bitTarget]="shlLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['SHL']" [color]="'Yellow'" [bitTarget]="AluOperationLines.SHL"
         transform="translate(69,0)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['AND']" [color]="'Yellow'" [bitTarget]="andLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['AND']" [color]="'Yellow'" [bitTarget]="AluOperationLines.AND"
         transform="translate(0,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['OR']" [color]="'Yellow'" [bitTarget]="orrLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['OR']" [color]="'Yellow'" [bitTarget]="AluOperationLines.ORR"
         transform="translate(23,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['XOR']" [color]="'Yellow'" [bitTarget]="xorLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['XOR']" [color]="'Yellow'" [bitTarget]="AluOperationLines.XOR"
         transform="translate(46,23)"></g>
-    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['NOT']" [color]="'Yellow'" [bitTarget]="notLine"
+    <g rc-tact-switch [part]="part()" [valueIn]="valueIn()" [description]="['NOT']" [color]="'Yellow'" [bitTarget]="AluOperationLines.NOT"
         transform="translate(69,23)"></g>
 </svg:g>

--- a/src/app/components/upper_enclosure/displays/display_a/display_a_a2c.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_a/display_a_a2c.component.ts
@@ -12,13 +12,7 @@ import { TactileSwitchComponent } from '../../../shared/switches/tact_switch/tac
 })
 export class DisplayAA2CComponent {
 
-  addLine: number = AluOperationLines.ADD;
-  incLine: number = AluOperationLines.INC;
-  shlLine: number = AluOperationLines.SHL;
-  andLine: number = AluOperationLines.AND;
-  orrLine: number = AluOperationLines.ORR;
-  xorLine: number = AluOperationLines.XOR;
-  notLine: number = AluOperationLines.NOT;
+  protected readonly AluOperationLines = AluOperationLines;
 
   readonly part = input.required<CardOutput>();
   readonly valueIn = input.required<BitValue>();

--- a/src/app/components/upper_enclosure/displays/display_b/display_b.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_b/display_b.component.svg
@@ -13,54 +13,54 @@
       </g>
       }
 
-      <rect x="360" y="9.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(lodLine)" />
+      <rect x="360" y="9.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(OperationLines.ILOD)" />
       <rect x="360" y="9.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(361.77557 10.2)" fill="black">
         <tspan class="d-text6" x="7.495527" y="6">LOAD</tspan>
       </text>
-      <rect x="360" y="18.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(mscLine)" />
+      <rect x="360" y="18.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(OperationLines.IMSC)" />
       <rect x="360" y="18.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(361.77557 19.2)" fill="black">
         <tspan class="d-text6" x="8.1649607" y="6">MISC</tspan>
       </text>
-      <rect x="360" y="27.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(strLine)" />
+      <rect x="360" y="27.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(OperationLines.ISTR)" />
       <rect x="360" y="27.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(361.77557 28.2)" fill="black">
         <tspan class="d-text6" x="5.3832224" y="6">STORE</tspan>
       </text>
-      <rect x="360" y="36.999977" width="35" height="8" class="indYellow"  [class.on]="card().operation.bit(incLine)"/>
+      <rect x="360" y="36.999977" width="35" height="8" class="indYellow"  [class.on]="card().operation.bit(OperationLines.IINC)"/>
       <rect x="360" y="36.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(361.77557 37.2)" fill="black">
         <tspan class="d-text6" x="6.4965037" y="6">INCXY</tspan>
       </text>
-      <rect x="396" y="27.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(gtoLine)" />
+      <rect x="396" y="27.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(OperationLines.IGTO)" />
       <rect x="396" y="27.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(397.77557 28.2)" fill="black">
         <tspan class="d-text6" x="6.8846873" y="6">GOTO</tspan>
       </text>
-      <rect x="396" y="36.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(mv8Line)" />
+      <rect x="396" y="36.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(OperationLines.IMV8)" />
       <rect x="396" y="36.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(397.77557 37.2)" fill="black">
         <tspan class="d-text6" x="7.1630076" y="6">MOV8</tspan>
       </text>
-      <rect x="432" y="27.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(setLine)" />
+      <rect x="432" y="27.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(OperationLines.ISET)" />
       <rect x="432" y="27.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(433.77557 28.2)" fill="black">
         <tspan class="d-text6" x="6.0497263" y="6">SETAB</tspan>
       </text>
-      <rect x="432" y="36.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(m16Line)" />
+      <rect x="432" y="36.999977" width="35" height="8" class="indYellow" [class.on]="card().operation.bit(OperationLines.IM16)" />
       <rect x="432" y="36.999977" width="35" height="8" class="indOutline" />
       <text transform="translate(433.77557 37.2)" fill="black">
         <tspan class="d-text6" x="5.4945505" y="6">MOV16</tspan>
       </text>
 
-      <rect x="268" y="115.99998" width="35" height="17" class="indRed" [class.on]="card().clockCtrl.bit(hltLine)" />
+      <rect x="268" y="115.99998" width="35" height="17" class="indRed" [class.on]="card().clockCtrl.bit(ClockCtrlLines.HLT)" />
       <rect x="268" y="115.99998" width="35" height="17" class="indOutline" />
       <text transform="translate(268.88062 119.406825)" fill="black">
         <tspan class="d-text8" x="6.630414" y="8">HALT</tspan>
       </text>
 
-      <rect x="250" y="115.99998" width="17" height="17" class="indYellow" [class.on]="card().clock.bit(clkLine)" />
+      <rect x="250" y="115.99998" width="17" height="17" class="indYellow" [class.on]="card().clock.bit(ClockLines.CLK)" />
       <rect x="250" y="115.99998" width="17" height="17" class="indOutline" />
       <text transform="translate(250.86242 120.79813)" fill="black">
         <tspan class="d-text7" x=".80010144" y="6">CLK</tspan>

--- a/src/app/components/upper_enclosure/displays/display_b/display_b.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_b/display_b.component.ts
@@ -14,18 +14,9 @@ import { DoubleByteLedLightBarComponent } from '../../../shared/leds/byte_llb/db
 })
 export class DisplayBComponent {
 
-  setLine = OperationLines.ISET;
-  mv8Line = OperationLines.IMV8;
-  m16Line = OperationLines.IM16;
-  gtoLine = OperationLines.IGTO;
-  mscLine = OperationLines.IMSC;
-  strLine = OperationLines.ISTR;
-  lodLine = OperationLines.ILOD;
-  incLine = OperationLines.IINC;
-
-  clkLine = ClockLines.CLK;
-
-  hltLine = ClockCtrlLines.HLT;
+  protected readonly OperationLines = OperationLines;
+  protected readonly ClockLines = ClockLines;
+  protected readonly ClockCtrlLines = ClockCtrlLines;
 
   readonly card = input.required<IDisplayBCard>();
 }

--- a/src/app/components/upper_enclosure/displays/display_b/display_b_alu.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_b/display_b_alu.component.svg
@@ -1,41 +1,41 @@
 <svg:g>
     <!-- Origin at top left CL led light bar -->
-    <rect x="0" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(clLine)" />
+    <rect x="0" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(AluFunctionClLines.CL)" />
     <rect x="0" y="0" width="8" height="17" class="indOutline" />
     <text transform="translate(1.6967 1.406848)" fill="black">
         <tspan class="d-text6" x="0" y="6">C</tspan>
         <tspan class="d-text6" x=".4729043" y="13">L</tspan>
     </text>
-    <rect x="9" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(f2Line)" />
+    <rect x="9" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(AluFunctionClLines.F2)" />
     <rect x="9" y="0" width="8" height="17" class="indOutline" />
     <text transform="translate(10.6967 2.906825)" fill="black">
         <tspan class="d-text9" x="0" y="9">2</tspan>
     </text>
-    <rect x="18" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(f1Line)" />
+    <rect x="18" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(AluFunctionClLines.F1)" />
     <rect x="18" y="0" width="8" height="17" class="indOutline" />
     <text transform="translate(19.6967 2.906825)" fill="black">
         <tspan class="d-text9" x="0" y="9">1</tspan>
     </text>
-    <rect x="27" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(f0Line)" />
+    <rect x="27" y="0" width="8" height="17" class="indGreen" [class.on]="aluFuncCl().bit(AluFunctionClLines.F0)" />
     <rect x="27" y="0" width="8" height="17" class="indOutline" />
     <text transform="translate(28.6967 2.906825)" fill="black">
         <tspan class="d-text9" x="0" y="9">0</tspan>
     </text>
     
     <g rc-alu-op-llb [value]="alu()" [description]="'INC'" [color]="'Yellow'" 
-        [bitTarget]="incLine" transform="translate(18 18)"></g>
+        [bitTarget]="AluOperationLines.INC" transform="translate(18 18)"></g>
     <g rc-alu-op-llb [value]="alu()" [description]="'OR'" [color]="'Yellow'" 
-        [bitTarget]="orrLine" transform="translate(18 27)"></g>
+        [bitTarget]="AluOperationLines.ORR" transform="translate(18 27)"></g>
     <g rc-alu-op-llb [value]="alu()" [description]="'NOT'" [color]="'Yellow'" 
-        [bitTarget]="notLine" transform="translate(18 36)"></g>
+        [bitTarget]="AluOperationLines.NOT" transform="translate(18 36)"></g>
     <g rc-alu-op-llb [value]="alu()" [description]="'NOP'" [color]="'Yellow'" 
         [bitTarget]="-1" transform="translate(18 45)"></g>
     <g rc-alu-op-llb [value]="alu()" [description]="'ADD'" [color]="'Yellow'" 
-        [bitTarget]="addLine" transform="translate(0 18)"></g>
+        [bitTarget]="AluOperationLines.ADD" transform="translate(0 18)"></g>
     <g rc-alu-op-llb [value]="alu()" [description]="'AND'" [color]="'Yellow'" 
-        [bitTarget]="andLine" transform="translate(0 27)"></g>
+        [bitTarget]="AluOperationLines.AND" transform="translate(0 27)"></g>
     <g rc-alu-op-llb [value]="alu()" [description]="'XOR'" [color]="'Yellow'" 
-        [bitTarget]="xorLine" transform="translate(0 36)"></g>
+        [bitTarget]="AluOperationLines.XOR" transform="translate(0 36)"></g>
     <g rc-alu-op-llb [value]="alu()" [description]="'SHL'" [color]="'Yellow'" 
-        [bitTarget]="shlLine" transform="translate(0 45)"></g>
+        [bitTarget]="AluOperationLines.SHL" transform="translate(0 45)"></g>
 </svg:g>

--- a/src/app/components/upper_enclosure/displays/display_b/display_b_alu.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_b/display_b_alu.component.ts
@@ -16,18 +16,8 @@ import { AluOperationLedLightBarComponent } from '../../../shared/leds/alu_op_ll
 })
 export class DisplayBAluComponent {
 
-  addLine: number = AluOperationLines.ADD;
-  incLine: number = AluOperationLines.INC;
-  shlLine: number = AluOperationLines.SHL;
-  andLine: number = AluOperationLines.AND;
-  orrLine: number = AluOperationLines.ORR;
-  xorLine: number = AluOperationLines.XOR;
-  notLine: number = AluOperationLines.NOT;
-
-  clLine: number = AluFunctionClLines.CL;
-  f2Line: number = AluFunctionClLines.F2;
-  f1Line: number = AluFunctionClLines.F1;
-  f0Line: number = AluFunctionClLines.F0;
+  protected readonly AluOperationLines = AluOperationLines;
+  protected readonly AluFunctionClLines = AluFunctionClLines;
 
   readonly alu = input.required<BitValue>();
   readonly aluFuncCl = input.required<BitValue>();

--- a/src/app/components/upper_enclosure/displays/display_b/display_b_condition.component.svg
+++ b/src/app/components/upper_enclosure/displays/display_b/display_b_condition.component.svg
@@ -1,18 +1,18 @@
 <svg:g>
     <!-- Origin at top left led light bar -->
-    <rect x="0" y="0" width="17" height="17" class="indGreen" [class.on]="value().bit(snLine)" />
+    <rect x="0" y="0" width="17" height="17" class="indGreen" [class.on]="value().bit(ConditionLines.SN)" />
     <rect x="0" y="0" width="17" height="17" class="indOutline" />
     <text transform="translate(0.86242 2.406845)" fill="black">
         <tspan class="d-text10" x="4.2737343" y="10">S</tspan>
     </text>
 
-    <rect x="18" y="0" width="17" height="17" class="indGreen" [class.on]="value().bit(cyLine)" />
+    <rect x="18" y="0" width="17" height="17" class="indGreen" [class.on]="value().bit(ConditionLines.CY)" />
     <rect x="18" y="0" width="17" height="17" class="indOutline" />
     <text transform="translate(18.86242 2.406845)" fill="black">
         <tspan class="d-text10" x="3.9978553" y="10">C</tspan>
     </text>
 
-    <rect x="36" y="0" width="17" height="17" class="indGreen" [class.on]="value().bit(ezLine)" />
+    <rect x="36" y="0" width="17" height="17" class="indGreen" [class.on]="value().bit(ConditionLines.EZ)" />
     <rect x="36" y="0" width="17" height="17" class="indOutline" />
     <text transform="translate(36.86242 2.406845)" fill="black">
         <tspan class="d-text10" x="4.554496" y="10">Z</tspan>

--- a/src/app/components/upper_enclosure/displays/display_b/display_b_condition.component.ts
+++ b/src/app/components/upper_enclosure/displays/display_b/display_b_condition.component.ts
@@ -11,9 +11,7 @@ import { ConditionLines } from '@paul80nd/relay-computer-model';
 })
 export class DisplayBConditionComponent {
 
-  cyLine = ConditionLines.CY;
-  snLine = ConditionLines.SN;
-  ezLine = ConditionLines.EZ;
+  protected readonly ConditionLines = ConditionLines;
 
   readonly value = input.required<BitValue>();
 

--- a/src/app/program-loader.spec.ts
+++ b/src/app/program-loader.spec.ts
@@ -24,8 +24,10 @@ describe('parseAssembledProgram', () => {
     expect(parseAssembledProgram('00zz11')).toBeNull();
   });
 
-  it('rejects upper-case hex (assembler emits lower-case)', () => {
-    expect(parseAssembledProgram('00AABB')).toBeNull();
+  it('accepts upper-case and mixed-case hex (assembler emits lower-case)', () => {
+    // 00 AA BB -> offset 0xAA00, program [0xBB].
+    expect(parseAssembledProgram('00AABB')).toEqual({ offset: 0xaa00, prog: [0xbb] });
+    expect(parseAssembledProgram('00aAbB')).toEqual({ offset: 0xaa00, prog: [0xbb] });
   });
 
   it('rejects an empty string', () => {

--- a/src/app/program-loader.spec.ts
+++ b/src/app/program-loader.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parseAssembledProgram } from './program-loader';
+
+describe('parseAssembledProgram', () => {
+  it('splits hex byte-pairs into a little-endian offset and program bytes', () => {
+    // 00 01 -> offset 0x0100 (256); remaining bytes are the program.
+    expect(parseAssembledProgram('0001aabbcc')).toEqual({
+      offset: 256,
+      prog: [0xaa, 0xbb, 0xcc],
+    });
+  });
+
+  it('reads the offset low byte first', () => {
+    // 34 12 -> 0x1234.
+    expect(parseAssembledProgram('341200')).toEqual({ offset: 0x1234, prog: [0x00] });
+  });
+
+  it('loads at offset zero with no leading address bytes set', () => {
+    expect(parseAssembledProgram('000041')).toEqual({ offset: 0, prog: [0x41] });
+  });
+
+  it('rejects non-hex text', () => {
+    expect(parseAssembledProgram('hello world')).toBeNull();
+    expect(parseAssembledProgram('00zz11')).toBeNull();
+  });
+
+  it('rejects upper-case hex (assembler emits lower-case)', () => {
+    expect(parseAssembledProgram('00AABB')).toBeNull();
+  });
+
+  it('rejects an empty string', () => {
+    expect(parseAssembledProgram('')).toBeNull();
+  });
+
+  it('rejects input with only an offset and no program bytes', () => {
+    // Two bytes = offset only, nothing to load.
+    expect(parseAssembledProgram('0001')).toBeNull();
+  });
+
+  it('treats trailing odd nibble as its own byte (min 3 bytes still required)', () => {
+    // 'aabbc' -> [0xaa, 0xbb, 0x0c]: three bytes, so it parses.
+    expect(parseAssembledProgram('aabbc')).toEqual({ offset: 0xbbaa, prog: [0x0c] });
+  });
+});

--- a/src/app/program-loader.ts
+++ b/src/app/program-loader.ts
@@ -18,10 +18,11 @@ export interface AssembledProgram {
  * Returns null when the text isn't a recognisable program — non-hex characters,
  * or fewer than three bytes (i.e. no program after the offset).
  *
- * Note: only lower-case hex is accepted, matching the assembler's output.
+ * Hex is accepted in either case; the assembler emits lower-case, but hand-typed
+ * or edited input may use upper-case.
  */
 export function parseAssembledProgram(text: string): AssembledProgram | null {
-  if (!/^[0-9a-f]*$/.test(text)) {
+  if (!/^[0-9a-fA-F]*$/.test(text)) {
     return null;
   }
   const parts = text.match(/.{1,2}/g);

--- a/src/app/program-loader.ts
+++ b/src/app/program-loader.ts
@@ -1,0 +1,38 @@
+/**
+ * A program parsed from an assembled hex string, ready to hand to
+ * `memory.loadProgram(offset, prog)`.
+ */
+export interface AssembledProgram {
+  /** Little-endian load address taken from the first two bytes. */
+  offset: number;
+  /** The program bytes (everything after the two offset bytes). */
+  prog: number[];
+}
+
+/**
+ * Parses the clipboard contents of the assembler/IDE (editor.relaycomputer.co.uk)
+ * as an assembled program: a stream of hex byte-pairs where the first two bytes
+ * are the little-endian load offset (low byte first) and the remainder is the
+ * program itself.
+ *
+ * Returns null when the text isn't a recognisable program — non-hex characters,
+ * or fewer than three bytes (i.e. no program after the offset).
+ *
+ * Note: only lower-case hex is accepted, matching the assembler's output.
+ */
+export function parseAssembledProgram(text: string): AssembledProgram | null {
+  if (!/^[0-9a-f]*$/.test(text)) {
+    return null;
+  }
+  const parts = text.match(/.{1,2}/g);
+  if (!parts) {
+    return null;
+  }
+  const values = parts.map(p => parseInt(p, 16));
+  if (values.length <= 2) {
+    return null;
+  }
+  const offset = values[0] + (values[1] << 8);
+  const prog = values.slice(2);
+  return { offset, prog };
+}

--- a/src/app/render-loop.spec.ts
+++ b/src/app/render-loop.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ApplicationRef } from '@angular/core';
+import { MAX_CONSECUTIVE_ERRORS, startRenderLoop } from './render-loop';
+
+// The loop drives change detection once per animation frame. A single throwing
+// frame is caught and logged, but a sustained per-frame throw stops the loop
+// after MAX_CONSECUTIVE_ERRORS. Fake timers drive requestAnimationFrame.
+describe('startRenderLoop', () => {
+  let detectChanges: ReturnType<typeof vi.fn>;
+  let appRef: ApplicationRef;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    detectChanges = vi.fn();
+    appRef = { components: [{ changeDetectorRef: { detectChanges } }] } as unknown as ApplicationRef;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('runs change detection every frame and keeps scheduling', () => {
+    startRenderLoop(appRef);
+    vi.advanceTimersToNextFrame();
+    expect(detectChanges).toHaveBeenCalledTimes(1);
+    vi.advanceTimersToNextFrame();
+    vi.advanceTimersToNextFrame();
+    expect(detectChanges).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops after MAX_CONSECUTIVE_ERRORS consecutive throws', () => {
+    detectChanges.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    startRenderLoop(appRef);
+
+    // Advance well past the threshold; the loop should stop scheduling frames.
+    for (let i = 0; i < MAX_CONSECUTIVE_ERRORS + 5; i++) {
+      vi.advanceTimersToNextFrame();
+    }
+
+    expect(detectChanges).toHaveBeenCalledTimes(MAX_CONSECUTIVE_ERRORS);
+    expect(console.error).toHaveBeenCalledWith(
+      `Render loop stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive errors.`,
+    );
+  });
+
+  it('resets the error streak on any successful frame', () => {
+    let calls = 0;
+    detectChanges.mockImplementation(() => {
+      // Throw for the first few frames, then succeed forever after.
+      if (++calls <= MAX_CONSECUTIVE_ERRORS - 1) {
+        throw new Error('transient');
+      }
+    });
+    startRenderLoop(appRef);
+
+    const frames = MAX_CONSECUTIVE_ERRORS * 3;
+    for (let i = 0; i < frames; i++) {
+      vi.advanceTimersToNextFrame();
+    }
+
+    // Never hit MAX in a row, so it never stopped: every frame ran.
+    expect(detectChanges).toHaveBeenCalledTimes(frames);
+    expect(console.error).not.toHaveBeenCalledWith(
+      `Render loop stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive errors.`,
+    );
+  });
+});

--- a/src/app/render-loop.ts
+++ b/src/app/render-loop.ts
@@ -25,7 +25,17 @@ import { ApplicationRef } from '@angular/core';
  * a synchronous check regardless, which is exactly what the non-reactive model
  * needs each frame.
  */
+/**
+ * A frame that throws is caught and logged so one bad check doesn't kill
+ * rendering. But a *persistent* per-frame throw would spam the console at ~60fps
+ * and burn cycles, so after this many consecutive failures we stop the loop and
+ * log once. Any successful frame resets the streak, so transient errors don't
+ * accumulate toward a stop.
+ */
+export const MAX_CONSECUTIVE_ERRORS = 10;
+
 export function startRenderLoop(appRef: ApplicationRef): void {
+  let consecutiveErrors = 0;
   const tick = () => {
     // Force synchronous change detection over the root view (and its CheckAlways
     // children) every frame. detectChanges() bypasses the dirty gating that
@@ -35,8 +45,13 @@ export function startRenderLoop(appRef: ApplicationRef): void {
       for (const c of appRef.components) {
         c.changeDetectorRef.detectChanges();
       }
+      consecutiveErrors = 0;
     } catch (err) {
       console.error(err);
+      if (++consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        console.error(`Render loop stopped after ${MAX_CONSECUTIVE_ERRORS} consecutive errors.`);
+        return; // stop scheduling frames
+      }
     }
     requestAnimationFrame(tick);
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,10 +14,12 @@ import {
   importIcon,
   libraryIcon,
   listIcon,
-  rulerPencilIcon
+  rulerPencilIcon,
+  timesIcon
 } from '@clr/angular/icon';
 
-ClarityIcons.addIcons(angleIcon, clockIcon, flaskIcon, importIcon, helpInfoIcon, libraryIcon, listIcon, rulerPencilIcon);
+// timesIcon backs the close button on Clarity's alert banner.
+ClarityIcons.addIcons(angleIcon, clockIcon, flaskIcon, importIcon, helpInfoIcon, libraryIcon, listIcon, rulerPencilIcon, timesIcon);
 
 if (environment.production) {
   enableProdMode();

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": []
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
Front-panel (Angular/SVG) view-layer improvements. The simulation itself lives in
the separate `@paul80nd/relay-computer-model` package; this is rendering-shell work
over it. Items tracked in `TODO.md`.

## Cleanup & refactor
- Remove standalone-migration dead code (`providers: [ByteLedsComponent]` + duplicate
  imports) from the register LED components.
- Collapse ~122 per-member enum-alias fields to a single exposed enum object per
  component (`Lines = RegABCDLines`, referenced as `Lines.RLA`).

## Front-panel LEDs brought live
Several LEDs were commented-out blank circles despite the model driving the bits:
- Control Card A: AT12/AT14 abort, B2M/MEW memory.
- Control Card B: J/M/X/Y select & load LEDs, nudged onto their silkscreen labels.
- Decoder card: INCXY / STORE / LOAD / MOV16.

(SDS/SAS remain commented — blocked on the model exposing `sds` via `IControlCard`;
documented in-code and in `TODO.md`.)

## Behaviour improvements
- **Live OS theme** — follow `prefers-color-scheme` changes while the app is open
  (both directions), not only at load.
- **Clipboard errors as a toast** — replace native `alert()` with a dismissible,
  bottom-docked Clarity alert banner that auto-dismisses after 6s. Register
  `timesIcon` for its close button and swap the deprecated `ClrIconModule` for the
  standalone `ClrIcon`.
- **Parser accepts upper-/mixed-case hex** (`[0-9a-fA-F]`).
- **`state_view` paging clamp** — `nextPage`/`prevPage` clamp `offset` to `[0, 0xFF00]`.
- **Render-loop backoff** — stop the rAF loop after 10 consecutive errors (streak
  resets on any good frame) instead of spamming the console at ~60fps.

## Tests & CI
- Vitest unit-test harness (`@angular/build:unit-test`, `npm test`).
- Extract the clipboard parser to a pure, tested `parseAssembledProgram()`.
- 35 tests: hex/dec pipes, the parser, the control_switches 500ms debounce state
  machine, `state_view` paging, and the render-loop error backoff.
- CI workflow (lint + build + test on push/PR to main) and Dependabot config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)