### PR TITLE
Group Angular packages together for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,18 @@ updates:
       # update via `registries: [...]`, and remove this ignore entry.
       - dependency-name: "@paul80nd/relay-computer-model"
     groups:
+      # Angular packages are versioned in lockstep and declare exact peer
+      # dependencies on each other (e.g. @angular/animations pins
+      # @angular/core@=x.y.z), so a partial bump fails `npm ci` with ERESOLVE.
+      # Keep the whole family — runtime, CLI/build tooling and @angular-eslint —
+      # in one PR across all update types so they move together. NB a publish-
+      # timing skew between members can still split a PR (one lands before the
+      # cooldown clears the rest); top up the straggler by hand to match and
+      # refresh the lockfile if that happens.
+      angular:
+        patterns:
+          - "@angular*"
+          - "@angular-eslint*"
       npm-patch-minor:
         update-types: ["patch", "minor"]
       npm-major:


### PR DESCRIPTION
## Why
PR #83 (grouped npm patch/minor bump) failed CI at `npm ci` with `ERESOLVE`:
Dependabot bumped most of the Angular family to `22.0.7` but left
`@angular/animations` and `@angular/platform-browser-dynamic` at `22.0.6`.
Angular packages are versioned in lockstep and declare **exact** peer
dependencies on each other (e.g. `@angular/animations@22.0.6` pins
`@angular/core@22.0.6`), so a partial bump can't install.

## Change
Add a dedicated `angular` group to the npm ecosystem in `dependabot.yml`,
matching `@angular*` and `@angular-eslint*` across all update types, so the
whole family always travels in a single PR and moves together.

## Note
This reduces but can't fully eliminate splits caused by publish-timing skew (one
family member becoming eligible before the 7-day cooldown clears the rest). If a
straggler still appears, top it up by hand to match and refresh the lockfile —
which is exactly the fix applied directly to #83 to unblock it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)