### PR TITLE
Ignore TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
       # DEPENDABOT_GHPR_TOKEN secret with read:packages), reference it from this
       # update via `registries: [...]`, and remove this ignore entry.
       - dependency-name: "@paul80nd/relay-computer-model"
+      # Angular's build/compiler-cli pin an exact TypeScript minor
+      # (@angular/build → typescript ">=6.0 <6.1"), so a TS major (e.g. 7.x)
+      # can't install until a future Angular adds support (#84 failed npm ci on
+      # exactly this). Ignore TS majors; patch/minor within the supported 6.x
+      # line still come through. Revisit when Angular's peer range widens.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # Angular packages are versioned in lockstep and declare exact peer
       # dependencies on each other (e.g. @angular/animations pins


### PR DESCRIPTION
## Why
Dependabot #84 tried to bump `typescript` 6.0.3 → 7.0.2 and failed `npm ci`:
`@angular/build` (and `compiler-cli`) declare `peer typescript@">=6.0 <6.1"`, so
a TypeScript **major** is outside Angular 22's supported range and can't install.
This isn't fixable here — it needs a future Angular release that supports TS 7.

## Change
Add an `ignore` entry for `typescript` `version-update:semver-major` to the npm
ecosystem in `dependabot.yml`. Patch/minor updates within the supported 6.x line
still come through; only majors are suppressed. Revisit when Angular's peer range
widens to allow the next TS major.

Companion to closing #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)